### PR TITLE
Implement auto login after registration

### DIFF
--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -20,21 +20,13 @@ test.describe('Authentication E2E', () => {
     await page.fill('input[name="password"]', 'TestPass123!');
     await page.fill('input[name="confirmPassword"]', 'TestPass123!');
     await page.click('button:has-text("Register")');
-    await expect(page.getByText(/registration successful! you can now log in\./i)).toBeVisible();
 
-    // Go back to login
-    await page.click('text=back to login');
-    await expect(page.getByRole('heading', { name: /login/i })).toBeVisible();
-
-    // Login with the new user
-    await page.fill('input[name="email"]', email);
-    await page.fill('input[name="password"]', 'TestPass123!');
-    await page.click('button:has-text("Login")');
-    // Wait for login success (alert or dashboard)
-    await page.waitForEvent('dialog').then(dialog => dialog.accept());
+    // After successful registration the user should be redirected to the dashboard
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.getByText(/dashboard - coming soon/i)).toBeVisible();
 
     // Request password reset
-    await page.click('text=forgot password');
+    await page.goto('/reset-password');
     await expect(page.getByRole('heading', { name: /reset password/i })).toBeVisible();
     await page.fill('input[name="email"]', 'test@example.com');
     await page.click('button:has-text("Send Reset Link")');
@@ -50,7 +42,7 @@ test.describe('Authentication E2E', () => {
     await page.fill('input[name="password"]', 'TestPass123!');
     await page.fill('input[name="confirmPassword"]', 'TestPass123!');
     await page.click('button:has-text("Register")');
-    await expect(page.getByText(/registration successful! you can now log in./i)).toBeVisible();
+    await expect(page).toHaveURL('/dashboard');
 
     // Now, try to register again with the same email.
     await page.goto('/register');

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 interface RegistrationForm {
   name: string;
@@ -12,7 +12,7 @@ const RegistrationPage: React.FC = () => {
   const [form, setForm] = useState<RegistrationForm>({ name: '', email: '', password: '', confirmPassword: '' });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
+  const navigate = useNavigate();
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -21,7 +21,6 @@ const RegistrationPage: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    setSuccess(false);
     if (form.password !== form.confirmPassword) {
       setError('Passwords do not match');
       return;
@@ -39,8 +38,21 @@ const RegistrationPage: React.FC = () => {
         setLoading(false);
         return;
       }
+      // Automatically log in after successful registration
+      const loginRes = await fetch('/api/v1/users/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: form.email, password: form.password }),
+      });
+
       setLoading(false);
-      setSuccess(true);
+      if (loginRes.ok) {
+        alert('Registration successful!');
+        navigate('/dashboard');
+      } else {
+        // Fallback: show generic message if auto login fails
+        navigate('/login');
+      }
     } catch (err) {
       setError('Network error');
       setLoading(false);
@@ -101,7 +113,6 @@ const RegistrationPage: React.FC = () => {
             />
           </div>
           {error && <div className="text-red-600 dark:text-red-400 text-sm">{error}</div>}
-          {success && <div className="text-green-600 dark:text-green-400 text-sm">Registration successful! You can now log in.</div>}
           <button
             type="submit"
             disabled={loading}


### PR DESCRIPTION
## Summary
- implement auto login after registration
- update e2e tests for redirect to dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npx playwright test` *(fails: Cannot find module '@testing-library/react')*

------
https://chatgpt.com/codex/tasks/task_e_685866c5a064832b92e0698500750a64